### PR TITLE
Build a 16.04 image with latest itzo-launcher

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - "*"
     tags-ignore:
       - v*
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ This needs [packer](https://www.packer.io/).
 
 A GitHub Action is configured to build images automatically for every push. The image name is based on `git describe`. For example:
 
-    git tag -am "v0.1.2-foo1" v0.1.2-foo1
+    git tag -am "foo1" foo1
     git push --tags
 
-The resulting image in this case will be called `elotl-kipdev-v0.1.2-foo1` on AWS, and `elotl-kipdev-v0-1-2-foo1` on GCE.
+The resulting image in this case will be called `elotl-kipdev-foo1` on AWS, and `elotl-kipdev-foo1` on GCE.
 
 Git tags with a semantic version like `v1.2.3` will update `elotl-kip-latest` on GCE (since on GCE, Kip uses this fixed image name by default), and create a new `elotl-kip-<version>` image on AWS (on AWS, by the default the latest AMI named `elotl-kip-*` is used by kip).

--- a/aws-provision.sh
+++ b/aws-provision.sh
@@ -20,13 +20,13 @@ VERSION_ID=$(. /etc/os-release; echo $VERSION_ID)
 curl -sfL https://nvidia.github.io/libnvidia-container/gpgkey | sudo apt-key add -
 curl -sfL https://nvidia.github.io/libnvidia-container/$DIST/libnvidia-container.list | sudo tee /etc/apt/sources.list.d/libnvidia-container.list
 sudo add-apt-repository -y ppa:graphics-drivers/ppa
-echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
+#echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+#curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
 sudo apt-get update -y
 sudo apt-get install -y iproute2 ipset iptables nfs-common ssl-cert libnvidia-container-tools
-sudo apt-get install -y --no-install-recommends nvidia-cuda-toolkit nvidia-driver-430 podman
+sudo apt-get install -y --no-install-recommends nvidia-cuda-toolkit nvidia-430
 
-curl -sfL https://toolbelt.treasuredata.com/sh/install-ubuntu-bionic-td-agent3.sh | sh
+curl -sfL https://toolbelt.treasuredata.com/sh/install-ubuntu-xenial-td-agent3.sh | sh
 sudo sed -i '/^User=.*$/d' /lib/systemd/system/td-agent.service
 sudo sed -i '/^Group=.*$/d' /lib/systemd/system/td-agent.service
 sudo apt-get install -y g++ make
@@ -46,7 +46,6 @@ sudo mv /tmp/aws-fluentd-cell.conf /etc/td-agent/td-agent.conf
 sudo REGION=us-east-1 CLUSTER_NAME=dummy /opt/td-agent/embedded/bin/fluentd --dry-run -c /etc/td-agent/td-agent.conf
 sudo systemctl daemon-reload
 sudo systemctl enable td-agent
-sudo systemctl enable podman.socket
 #curl -sfLO https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
 #sudo dpkg -i amazon-cloudwatch-agent.deb && rm amazon-cloudwatch-agent.deb
 #sudo cp /tmp/aws-cloudwatch-agent.conf /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
@@ -68,5 +67,4 @@ sudo rm -rf /root/.ssh
 sudo rm -rf /home/packer/.ssh
 sudo rm -rf /home/ubuntu/.ssh
 
-podman system info
 itzo --version

--- a/aws-provision.sh
+++ b/aws-provision.sh
@@ -17,14 +17,22 @@ done
 
 DIST=$(. /etc/os-release; echo $ID$VERSION_ID)
 VERSION_ID=$(. /etc/os-release; echo $VERSION_ID)
+
 curl -sfL https://nvidia.github.io/libnvidia-container/gpgkey | sudo apt-key add -
 curl -sfL https://nvidia.github.io/libnvidia-container/$DIST/libnvidia-container.list | sudo tee /etc/apt/sources.list.d/libnvidia-container.list
 sudo add-apt-repository -y ppa:graphics-drivers/ppa
-#echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-#curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
+
+echo "deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/Release.key | sudo apt-key add -
+
 sudo apt-get update -y
 sudo apt-get install -y iproute2 ipset iptables nfs-common ssl-cert libnvidia-container-tools
 sudo apt-get install -y --no-install-recommends nvidia-cuda-toolkit nvidia-430
+
+sudo apt-get install -y podman
+# Remove parameter not supported by systemd on 16.04.
+sudo sed -i '/StartLimitIntervalSec/d' /usr/lib/systemd/system/podman.service
+sudo systemctl daemon-reload
 
 curl -sfL https://toolbelt.treasuredata.com/sh/install-ubuntu-xenial-td-agent3.sh | sh
 sudo sed -i '/^User=.*$/d' /lib/systemd/system/td-agent.service
@@ -50,6 +58,7 @@ sudo systemctl enable td-agent
 #sudo dpkg -i amazon-cloudwatch-agent.deb && rm amazon-cloudwatch-agent.deb
 #sudo cp /tmp/aws-cloudwatch-agent.conf /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
 
+sudo systemctl enable podman.socket
 
 sudo dpkg -i /tmp/$KIP_PACKAGE
 
@@ -66,5 +75,7 @@ sudo mkdir -p /var/log/journal
 sudo rm -rf /root/.ssh
 sudo rm -rf /home/packer/.ssh
 sudo rm -rf /home/ubuntu/.ssh
+
+podman system info
 
 itzo --version

--- a/gce-provision.sh
+++ b/gce-provision.sh
@@ -16,12 +16,11 @@ sudo bash add-logging-agent-repo.sh
 curl -sSO https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh
 sudo bash add-monitoring-agent-repo.sh
 sudo add-apt-repository -y ppa:graphics-drivers/ppa
-echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
+#echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+#curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
 sudo apt-get update -y
 sudo apt-get install -y iproute2 ipset iptables nfs-common ssl-cert google-fluentd google-fluentd-catch-all-config-structured stackdriver-agent libnvidia-container-tools
-sudo apt-get install -y --no-install-recommends nvidia-cuda-toolkit nvidia-driver-430 podman
-sudo systemctl enable podman.socket
+sudo apt-get install -y --no-install-recommends nvidia-cuda-toolkit nvidia-430
 
 sudo dpkg -i /tmp/$KIP_PACKAGE
 
@@ -38,5 +37,4 @@ sudo rm -rf /root/.ssh
 sudo rm -rf /home/packer/.ssh
 sudo rm -rf /home/ubuntu/.ssh
 
-podman system info
 itzo --version

--- a/gce-provision.sh
+++ b/gce-provision.sh
@@ -16,11 +16,20 @@ sudo bash add-logging-agent-repo.sh
 curl -sSO https://dl.google.com/cloudagents/add-monitoring-agent-repo.sh
 sudo bash add-monitoring-agent-repo.sh
 sudo add-apt-repository -y ppa:graphics-drivers/ppa
-#echo "deb https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
-#curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_${VERSION_ID}/Release.key | sudo apt-key add -
+
+echo "deb http://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:stable.list
+curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/xUbuntu_18.04/Release.key | sudo apt-key add -
+
 sudo apt-get update -y
 sudo apt-get install -y iproute2 ipset iptables nfs-common ssl-cert google-fluentd google-fluentd-catch-all-config-structured stackdriver-agent libnvidia-container-tools
 sudo apt-get install -y --no-install-recommends nvidia-cuda-toolkit nvidia-430
+
+sudo apt-get install -y podman
+# Remove parameter not supported by systemd on 16.04.
+sudo sed -i '/StartLimitIntervalSec/d' /usr/lib/systemd/system/podman.service
+sudo systemctl daemon-reload
+
+sudo systemctl enable podman.socket
 
 sudo dpkg -i /tmp/$KIP_PACKAGE
 
@@ -36,5 +45,7 @@ sudo mkdir -p /var/log/journal
 sudo rm -rf /root/.ssh
 sudo rm -rf /home/packer/.ssh
 sudo rm -rf /home/ubuntu/.ssh
+
+podman system info
 
 itzo --version

--- a/packer.json
+++ b/packer.json
@@ -18,7 +18,7 @@
       "source_ami_filter": {
         "filters": {
           "virtualization-type": "hvm",
-          "name": "ubuntu/images/*ubuntu-bionic-18.04-amd64-server-*",
+          "name": "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*",
           "root-device-type": "ebs"
         },
         "owners": ["099720109477"],
@@ -32,7 +32,7 @@
       "type": "googlecompute",
       "account_file": "{{user `gce_account_file`}}",
       "project_id": "{{user `gce_project_id`}}",
-      "source_image_family": "ubuntu-1804-lts",
+      "source_image_family": "ubuntu-1604-lts",
       "ssh_username": "packer",
       "zone": "{{user `gce_zone`}}",
       "image_name": "elotl-kipdev-{{user `version` | replace_all \".\" \"-\" }}",


### PR DESCRIPTION
I reverted back to 16.04 for now, adding podman from the 18.04 kubic repo. It installs and works fine based on my (limited) testing; the only gotcha was that its systemd unit file used a parameter that is not supported by systemd on 16.04.